### PR TITLE
Add alt text to scikit-learn documentation

### DIFF
--- a/doc/modules/biclustering.rst
+++ b/doc/modules/biclustering.rst
@@ -61,7 +61,7 @@ small:
    :target: ../auto_examples/bicluster/images/sphx_glr_plot_spectral_biclustering_003.png
    :align: center
    :scale: 50
-   :alt:
+   :alt: The graph is a square heat map, 5x5, with axes from 0 to 250. The variance of the values within each bicluster is small, causing a checkerboard effect.
 
    An example of checkerboard biclusters.
 

--- a/doc/modules/biclustering.rst
+++ b/doc/modules/biclustering.rst
@@ -48,6 +48,7 @@ columns:
    :target: ../auto_examples/bicluster/images/sphx_glr_plot_spectral_coclustering_003.png
    :align: center
    :scale: 50
+   :alt:
 
    An example of biclusters formed by partitioning rows and columns.
 
@@ -60,6 +61,7 @@ small:
    :target: ../auto_examples/bicluster/images/sphx_glr_plot_spectral_biclustering_003.png
    :align: center
    :scale: 50
+   :alt:
 
    An example of checkerboard biclusters.
 

--- a/doc/modules/biclustering.rst
+++ b/doc/modules/biclustering.rst
@@ -48,7 +48,8 @@ columns:
    :target: ../auto_examples/bicluster/images/sphx_glr_plot_spectral_coclustering_003.png
    :align: center
    :scale: 50
-   :alt: The graph is a square heat map, 5x5, with axes from 0 to 250.  The darkest 5 squares of heat map run diagonally from top left to bottom right.
+   :alt: The graph is a square heat map, 5x5, with axes from 0 to 250.  The darkest 5 
+   squares of heat map run diagonally from top left to bottom right.
 
    An example of biclusters formed by partitioning rows and columns.
 
@@ -61,7 +62,8 @@ small:
    :target: ../auto_examples/bicluster/images/sphx_glr_plot_spectral_biclustering_003.png
    :align: center
    :scale: 50
-   :alt: The graph is a square heat map, 5x5, with axes from 0 to 250. The variance of the values within each bicluster is small, causing a checkerboard effect.
+   :alt: The graph is a square heat map, 5x5, with axes from 0 to 250. The variance of 
+   the values within each bicluster is small, causing a checkerboard effect.
 
    An example of checkerboard biclusters.
 

--- a/doc/modules/biclustering.rst
+++ b/doc/modules/biclustering.rst
@@ -48,7 +48,7 @@ columns:
    :target: ../auto_examples/bicluster/images/sphx_glr_plot_spectral_coclustering_003.png
    :align: center
    :scale: 50
-   :alt:
+   :alt: The graph is a square heat map, 5x5, with axes from 0 to 250.  The darkest 5 squares of heat map run diagonally from top left to bottom right.
 
    An example of biclusters formed by partitioning rows and columns.
 

--- a/doc/modules/calibration.rst
+++ b/doc/modules/calibration.rst
@@ -53,7 +53,10 @@ by showing the number of samples in each predicted probability bin.
 .. figure:: ../auto_examples/calibration/images/sphx_glr_plot_compare_calibration_001.png
    :target: ../auto_examples/calibration/plot_compare_calibration.html
    :align: center
-   :alt: Five plots comparing calibration classifiers. The first plot compares Logistic, Naive Bayes, SVC, and Random forest classifiers side by side with perfect calibration. The following four histograms isolate each classifier to describe their predicted probability on the x-axis and count on the y-axis.
+   :alt: Five plots comparing calibration classifiers. The first plot compares 
+   Logistic, Naive Bayes, SVC, and Random forest classifiers side by side with perfect 
+   calibration. The following four histograms isolate each classifier to describe 
+   their predicted probability on the x-axis and count on the y-axis.
 
 .. currentmodule:: sklearn.linear_model
 

--- a/doc/modules/calibration.rst
+++ b/doc/modules/calibration.rst
@@ -53,7 +53,7 @@ by showing the number of samples in each predicted probability bin.
 .. figure:: ../auto_examples/calibration/images/sphx_glr_plot_compare_calibration_001.png
    :target: ../auto_examples/calibration/plot_compare_calibration.html
    :align: center
-   :alt:
+   :alt: Five plots comparing calibration classifiers. The first plot compares Logistic, Naive Bayes, SVC, and Random forest classifiers side by side with perfect calibration. The following four histograms isolate each classifier to describe their predicted probability on the x-axis and count on the y-axis.
 
 .. currentmodule:: sklearn.linear_model
 

--- a/doc/modules/calibration.rst
+++ b/doc/modules/calibration.rst
@@ -53,6 +53,7 @@ by showing the number of samples in each predicted probability bin.
 .. figure:: ../auto_examples/calibration/images/sphx_glr_plot_compare_calibration_001.png
    :target: ../auto_examples/calibration/plot_compare_calibration.html
    :align: center
+   :alt:
 
 .. currentmodule:: sklearn.linear_model
 

--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -275,7 +275,10 @@ small, as shown in the example and cited reference.
    :target: ../auto_examples/cluster/plot_mini_batch_kmeans.html
    :align: center
    :scale: 100
-   :alt:
+   :alt: A figure of three panels with scatter plots for KMeans, MiniBatchKMeans,
+        and their difference.  Both methods have very similar results, the left and
+        middle panels show the three identified clusters.  The difference
+        panel highlights the <20 points that differ out of the 3000 points. 
 
 
 .. topic:: Examples:
@@ -314,7 +317,7 @@ is given.
    :target: ../auto_examples/cluster/plot_affinity_propagation.html
    :align: center
    :scale: 50
-   :alt:
+   :alt: Three distinct clusters created using affinity propagation.
 
 
 Affinity Propagation can be interesting as it chooses the number of
@@ -467,12 +470,12 @@ computed using a function of a gradient of the image.
 .. |noisy_img| image:: ../auto_examples/cluster/images/sphx_glr_plot_segmentation_toy_001.png
     :target: ../auto_examples/cluster/plot_segmentation_toy.html
     :scale: 50
-    :alt:
+    :alt: An image of connected nearly equally sized circles. The circles are in shades of green, blue, and yellow. The entire image is pixelated, blurry.
 
 .. |segmented_img| image:: ../auto_examples/cluster/images/sphx_glr_plot_segmentation_toy_002.png
     :target: ../auto_examples/cluster/plot_segmentation_toy.html
     :scale: 50
-    :alt:
+    :alt: An image of connected nearly equally sized circles. Each circle has a distinct color: dark green, light green, blue, and yellow. The clarity of the image is much better compared to the previous one.
 
 .. centered:: |noisy_img| |segmented_img|
 
@@ -653,12 +656,20 @@ the roll.
 .. |unstructured| image:: ../auto_examples/cluster/images/sphx_glr_plot_ward_structured_vs_unstructured_001.png
         :target: ../auto_examples/cluster/plot_ward_structured_vs_unstructured.html
         :scale: 49
-        :alt:
+        :alt: A 3D scatter plot of 1500 data points. Points are located along a swirl
+             or swiss roll. The six clusters are highlighted in different colours. 
+             The hierarchical clustering is performed without connectivity
+             constraints on the structure and is solely based on distance therefore
+             clusters extend to multiple layers of the roll.
 
 .. |structured| image:: ../auto_examples/cluster/images/sphx_glr_plot_ward_structured_vs_unstructured_002.png
         :target: ../auto_examples/cluster/plot_ward_structured_vs_unstructured.html
         :scale: 49
-        :alt:
+        :alt: A 3D scatter plot of 1500 data points. Points are located along a swirl
+              or swiss roll. The six clusters are highlighted in different colours.
+              The hierarchical clustering is performed with connectivity constraints
+              that respect the structure of the roll therefore the clusters form a nice
+              parcellation along the roll.
 
 .. centered:: |unstructured| |structured|
 
@@ -819,7 +830,7 @@ by black points below.
 .. |dbscan_results| image:: ../auto_examples/cluster/images/sphx_glr_plot_dbscan_001.png
         :target: ../auto_examples/cluster/plot_dbscan.html
         :scale: 50
-        :alt:
+        :alt: A bubble chart that maps three clusters, with the x-axis from -2.5 to 2 and the y-axis from -2 to 2.5. Outliers are indicated separately and are evenly spaced around the clusters.
 
 .. centered:: |dbscan_results|
 

--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -33,6 +33,7 @@ Overview of clustering methods
    :target: ../auto_examples/cluster/plot_cluster_comparison.html
    :align: center
    :scale: 50
+   :alt:
 
    A comparison of the clustering algorithms in scikit-learn
 
@@ -166,6 +167,7 @@ It suffers from various drawbacks:
    :target: ../auto_examples/cluster/plot_kmeans_assumptions.html
    :align: center
    :scale: 50
+   :alt:
 
 K-means is often referred to as Lloyd's algorithm. In basic terms, the
 algorithm has three steps. The first step chooses the initial centroids, with
@@ -182,6 +184,7 @@ until the centroids do not move significantly.
    :target: ../auto_examples/cluster/plot_kmeans_digits.html
    :align: right
    :scale: 35
+   :alt:
 
 K-means is equivalent to the expectation-maximization algorithm
 with a small, all-equal, diagonal covariance matrix.
@@ -272,6 +275,7 @@ small, as shown in the example and cited reference.
    :target: ../auto_examples/cluster/plot_mini_batch_kmeans.html
    :align: center
    :scale: 100
+   :alt:
 
 
 .. topic:: Examples:
@@ -310,6 +314,7 @@ is given.
    :target: ../auto_examples/cluster/plot_affinity_propagation.html
    :align: center
    :scale: 50
+   :alt:
 
 
 Affinity Propagation can be interesting as it chooses the number of
@@ -419,6 +424,7 @@ given sample.
    :target: ../auto_examples/cluster/plot_mean_shift.html
    :align: center
    :scale: 50
+   :alt:
 
 
 .. topic:: Examples:
@@ -461,10 +467,12 @@ computed using a function of a gradient of the image.
 .. |noisy_img| image:: ../auto_examples/cluster/images/sphx_glr_plot_segmentation_toy_001.png
     :target: ../auto_examples/cluster/plot_segmentation_toy.html
     :scale: 50
+    :alt:
 
 .. |segmented_img| image:: ../auto_examples/cluster/images/sphx_glr_plot_segmentation_toy_002.png
     :target: ../auto_examples/cluster/plot_segmentation_toy.html
     :scale: 50
+    :alt:
 
 .. centered:: |noisy_img| |segmented_img|
 
@@ -492,10 +500,12 @@ computed using a function of a gradient of the image.
 .. |coin_kmeans| image:: ../auto_examples/cluster/images/sphx_glr_plot_coin_segmentation_001.png
     :target: ../auto_examples/cluster/plot_coin_segmentation.html
     :scale: 65
+    :alt:
 
 .. |coin_discretize| image:: ../auto_examples/cluster/images/sphx_glr_plot_coin_segmentation_002.png
     :target: ../auto_examples/cluster/plot_coin_segmentation.html
     :scale: 65
+    :alt:
 
 Different label assignment strategies
 -------------------------------------
@@ -598,6 +608,7 @@ linkage strategies.
 .. image:: ../auto_examples/cluster/images/sphx_glr_plot_linkage_comparison_001.png
     :target: ../auto_examples/cluster/plot_linkage_comparison.html
     :scale: 43
+    :alt:
 
 Agglomerative cluster has a "rich get richer" behavior that leads to
 uneven cluster sizes. In this regard, single linkage is the worst
@@ -623,6 +634,7 @@ of the data, though more so in the case of small sample sizes.
 .. image:: ../auto_examples/cluster/images/sphx_glr_plot_agglomerative_dendrogram_001.png
     :target: ../auto_examples/cluster/plot_agglomerative_dendrogram.html
     :scale: 42
+    :alt:
 
 
 
@@ -641,10 +653,12 @@ the roll.
 .. |unstructured| image:: ../auto_examples/cluster/images/sphx_glr_plot_ward_structured_vs_unstructured_001.png
         :target: ../auto_examples/cluster/plot_ward_structured_vs_unstructured.html
         :scale: 49
+        :alt:
 
 .. |structured| image:: ../auto_examples/cluster/images/sphx_glr_plot_ward_structured_vs_unstructured_002.png
         :target: ../auto_examples/cluster/plot_ward_structured_vs_unstructured.html
         :scale: 49
+        :alt:
 
 .. centered:: |unstructured| |structured|
 
@@ -694,18 +708,22 @@ enable only merging of neighboring pixels on an image, as in the
 .. image:: ../auto_examples/cluster/images/sphx_glr_plot_agglomerative_clustering_001.png
     :target: ../auto_examples/cluster/plot_agglomerative_clustering.html
     :scale: 38
+    :alt:
 
 .. image:: ../auto_examples/cluster/images/sphx_glr_plot_agglomerative_clustering_002.png
     :target: ../auto_examples/cluster/plot_agglomerative_clustering.html
     :scale: 38
+    :alt:
 
 .. image:: ../auto_examples/cluster/images/sphx_glr_plot_agglomerative_clustering_003.png
     :target: ../auto_examples/cluster/plot_agglomerative_clustering.html
     :scale: 38
+    :alt:
 
 .. image:: ../auto_examples/cluster/images/sphx_glr_plot_agglomerative_clustering_004.png
     :target: ../auto_examples/cluster/plot_agglomerative_clustering.html
     :scale: 38
+    :alt:
 
 
 Varying the metric
@@ -730,14 +748,17 @@ each class.
 .. image:: ../auto_examples/cluster/images/sphx_glr_plot_agglomerative_clustering_metrics_005.png
     :target: ../auto_examples/cluster/plot_agglomerative_clustering_metrics.html
     :scale: 32
+    :alt:
 
 .. image:: ../auto_examples/cluster/images/sphx_glr_plot_agglomerative_clustering_metrics_006.png
     :target: ../auto_examples/cluster/plot_agglomerative_clustering_metrics.html
     :scale: 32
+    :alt:
 
 .. image:: ../auto_examples/cluster/images/sphx_glr_plot_agglomerative_clustering_metrics_007.png
     :target: ../auto_examples/cluster/plot_agglomerative_clustering_metrics.html
     :scale: 32
+    :alt:
 
 .. topic:: Examples:
 
@@ -798,6 +819,7 @@ by black points below.
 .. |dbscan_results| image:: ../auto_examples/cluster/images/sphx_glr_plot_dbscan_001.png
         :target: ../auto_examples/cluster/plot_dbscan.html
         :scale: 50
+        :alt:
 
 .. centered:: |dbscan_results|
 
@@ -883,6 +905,7 @@ potential reachable points.
 .. |optics_results| image:: ../auto_examples/cluster/images/sphx_glr_plot_optics_001.png
         :target: ../auto_examples/cluster/plot_optics.html
         :scale: 50
+        :alt:
 
 .. centered:: |optics_results|
 
@@ -1025,6 +1048,7 @@ the user is advised
 
 .. image:: ../auto_examples/cluster/images/sphx_glr_plot_birch_vs_minibatchkmeans_001.png
     :target: ../auto_examples/cluster/plot_birch_vs_minibatchkmeans.html
+    :alt:
 
 .. topic:: References:
 
@@ -1516,6 +1540,7 @@ Drawbacks
    :target: ../auto_examples/cluster/plot_adjusted_for_chance_measures.html
    :align: center
    :scale: 100
+   :alt:
 
 - These metrics **require the knowledge of the ground truth classes** while
   almost never available in practice or requires manual assignment by

--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -33,7 +33,6 @@ Overview of clustering methods
    :target: ../auto_examples/cluster/plot_cluster_comparison.html
    :align: center
    :scale: 50
-   :alt:
 
    A comparison of the clustering algorithms in scikit-learn
 
@@ -167,7 +166,6 @@ It suffers from various drawbacks:
    :target: ../auto_examples/cluster/plot_kmeans_assumptions.html
    :align: center
    :scale: 50
-   :alt:
 
 K-means is often referred to as Lloyd's algorithm. In basic terms, the
 algorithm has three steps. The first step chooses the initial centroids, with
@@ -184,7 +182,6 @@ until the centroids do not move significantly.
    :target: ../auto_examples/cluster/plot_kmeans_digits.html
    :align: right
    :scale: 35
-   :alt:
 
 K-means is equivalent to the expectation-maximization algorithm
 with a small, all-equal, diagonal covariance matrix.
@@ -427,7 +424,6 @@ given sample.
    :target: ../auto_examples/cluster/plot_mean_shift.html
    :align: center
    :scale: 50
-   :alt:
 
 
 .. topic:: Examples:
@@ -503,12 +499,10 @@ computed using a function of a gradient of the image.
 .. |coin_kmeans| image:: ../auto_examples/cluster/images/sphx_glr_plot_coin_segmentation_001.png
     :target: ../auto_examples/cluster/plot_coin_segmentation.html
     :scale: 65
-    :alt:
 
 .. |coin_discretize| image:: ../auto_examples/cluster/images/sphx_glr_plot_coin_segmentation_002.png
     :target: ../auto_examples/cluster/plot_coin_segmentation.html
     :scale: 65
-    :alt:
 
 Different label assignment strategies
 -------------------------------------
@@ -611,7 +605,6 @@ linkage strategies.
 .. image:: ../auto_examples/cluster/images/sphx_glr_plot_linkage_comparison_001.png
     :target: ../auto_examples/cluster/plot_linkage_comparison.html
     :scale: 43
-    :alt:
 
 Agglomerative cluster has a "rich get richer" behavior that leads to
 uneven cluster sizes. In this regard, single linkage is the worst
@@ -637,7 +630,6 @@ of the data, though more so in the case of small sample sizes.
 .. image:: ../auto_examples/cluster/images/sphx_glr_plot_agglomerative_dendrogram_001.png
     :target: ../auto_examples/cluster/plot_agglomerative_dendrogram.html
     :scale: 42
-    :alt:
 
 
 
@@ -719,22 +711,18 @@ enable only merging of neighboring pixels on an image, as in the
 .. image:: ../auto_examples/cluster/images/sphx_glr_plot_agglomerative_clustering_001.png
     :target: ../auto_examples/cluster/plot_agglomerative_clustering.html
     :scale: 38
-    :alt:
 
 .. image:: ../auto_examples/cluster/images/sphx_glr_plot_agglomerative_clustering_002.png
     :target: ../auto_examples/cluster/plot_agglomerative_clustering.html
     :scale: 38
-    :alt:
 
 .. image:: ../auto_examples/cluster/images/sphx_glr_plot_agglomerative_clustering_003.png
     :target: ../auto_examples/cluster/plot_agglomerative_clustering.html
     :scale: 38
-    :alt:
 
 .. image:: ../auto_examples/cluster/images/sphx_glr_plot_agglomerative_clustering_004.png
     :target: ../auto_examples/cluster/plot_agglomerative_clustering.html
     :scale: 38
-    :alt:
 
 
 Varying the metric
@@ -759,17 +747,14 @@ each class.
 .. image:: ../auto_examples/cluster/images/sphx_glr_plot_agglomerative_clustering_metrics_005.png
     :target: ../auto_examples/cluster/plot_agglomerative_clustering_metrics.html
     :scale: 32
-    :alt:
 
 .. image:: ../auto_examples/cluster/images/sphx_glr_plot_agglomerative_clustering_metrics_006.png
     :target: ../auto_examples/cluster/plot_agglomerative_clustering_metrics.html
     :scale: 32
-    :alt:
 
 .. image:: ../auto_examples/cluster/images/sphx_glr_plot_agglomerative_clustering_metrics_007.png
     :target: ../auto_examples/cluster/plot_agglomerative_clustering_metrics.html
     :scale: 32
-    :alt:
 
 .. topic:: Examples:
 
@@ -916,7 +901,6 @@ potential reachable points.
 .. |optics_results| image:: ../auto_examples/cluster/images/sphx_glr_plot_optics_001.png
         :target: ../auto_examples/cluster/plot_optics.html
         :scale: 50
-        :alt:
 
 .. centered:: |optics_results|
 
@@ -1059,7 +1043,6 @@ the user is advised
 
 .. image:: ../auto_examples/cluster/images/sphx_glr_plot_birch_vs_minibatchkmeans_001.png
     :target: ../auto_examples/cluster/plot_birch_vs_minibatchkmeans.html
-    :alt:
 
 .. topic:: References:
 
@@ -1551,7 +1534,6 @@ Drawbacks
    :target: ../auto_examples/cluster/plot_adjusted_for_chance_measures.html
    :align: center
    :scale: 100
-   :alt:
 
 - These metrics **require the knowledge of the ground truth classes** while
   almost never available in practice or requires manual assignment by

--- a/doc/modules/clustering.rst
+++ b/doc/modules/clustering.rst
@@ -466,12 +466,15 @@ computed using a function of a gradient of the image.
 .. |noisy_img| image:: ../auto_examples/cluster/images/sphx_glr_plot_segmentation_toy_001.png
     :target: ../auto_examples/cluster/plot_segmentation_toy.html
     :scale: 50
-    :alt: An image of connected nearly equally sized circles. The circles are in shades of green, blue, and yellow. The entire image is pixelated, blurry.
+    :alt: An image of connected nearly equally sized circles. The circles are in 
+    shades of green, blue, and yellow. The entire image is pixelated, blurry.
 
 .. |segmented_img| image:: ../auto_examples/cluster/images/sphx_glr_plot_segmentation_toy_002.png
     :target: ../auto_examples/cluster/plot_segmentation_toy.html
     :scale: 50
-    :alt: An image of connected nearly equally sized circles. Each circle has a distinct color: dark green, light green, blue, and yellow. The clarity of the image is much better compared to the previous one.
+    :alt: An image of connected nearly equally sized circles. Each circle has a 
+    distinct color: dark green, light green, blue, and yellow. The clarity of the image
+     is much better compared to the previous one.
 
 .. centered:: |noisy_img| |segmented_img|
 
@@ -815,7 +818,9 @@ by black points below.
 .. |dbscan_results| image:: ../auto_examples/cluster/images/sphx_glr_plot_dbscan_001.png
         :target: ../auto_examples/cluster/plot_dbscan.html
         :scale: 50
-        :alt: A bubble chart that maps three clusters, with the x-axis from -2.5 to 2 and the y-axis from -2 to 2.5. Outliers are indicated separately and are evenly spaced around the clusters.
+        :alt: A bubble chart that maps three clusters, with the x-axis from -2.5 to 2 
+        and the y-axis from -2 to 2.5. Outliers are indicated separately and are 
+        evenly spaced around the clusters.
 
 .. centered:: |dbscan_results|
 

--- a/doc/modules/covariance.rst
+++ b/doc/modules/covariance.rst
@@ -154,7 +154,9 @@ object to the same sample.
    :target: ../auto_examples/covariance/plot_covariance_estimation.html
    :align: center
    :scale: 65%
-   :alt:
+   :alt: A plot comparing shrinkage coefficients by regularization parameter: 
+   shrinkage coefficient on the x-axis and error: negative log-likelihood on test data 
+   on the y-axis.
 
    Bias-variance trade-off when setting the shrinkage: comparing the
    choices of Ledoit-Wolf and OAS estimators
@@ -343,7 +345,7 @@ attributes of a :class:`MinCovDet` robust covariance estimator object.
 .. |mahalanobis| image:: ../auto_examples/covariance/images/sphx_glr_plot_mahalanobis_distances_001.png
    :target: ../auto_examples/covariance/plot_mahalanobis_distances.html
    :scale: 49%
-   :alt:
+   :alt: Scatterplot with plotted Mahalanobis distances.
 
 
 

--- a/doc/modules/covariance.rst
+++ b/doc/modules/covariance.rst
@@ -181,7 +181,11 @@ object to the same sample.
    :target: ../auto_examples/covariance/plot_lw_vs_oas.html
    :align: center
    :scale: 75%
-   :alt: Two figures. One of them plots the Mean Squared Error difference between a LedoitWolf and an OAS estimator of the covariance with the y-axis from 0 to 60.  The other one compares the Shrinkage covariance estimation between the  LedoitWolf  and OAS, with the  y-axis from 0 to 1. In iboth figures the x-axis is the number of samples from 5 to 30.
+   :alt: Two figures. One of them plots the Mean Squared Error difference between a 
+   LedoitWolf and an OAS estimator of the covariance with the y-axis from 0 to 60.  
+   The other one compares the Shrinkage covariance estimation between the  LedoitWolf  
+   and OAS, with the  y-axis from 0 to 1. In iboth figures the x-axis is the number of 
+   samples from 5 to 30.
    
 
 
@@ -215,7 +219,9 @@ cross-validation to automatically set the ``alpha`` parameter.
    :target: ../auto_examples/covariance/plot_sparse_cov.html
    :align: center
    :scale: 60%
-   :alt: Various matrix using different estimators: Empircal covariance, Empircal precision, Ledoit-Wolf covariance, Ledoit-Wolf precision, GraphicaLassoCV covariance, GraphicaLassoCV precision, True covariance and True Precision.
+   :alt: Various matrix using different estimators: Empircal covariance, Empircal 
+   precision, Ledoit-Wolf covariance, Ledoit-Wolf precision, GraphicaLassoCV 
+   covariance, GraphicaLassoCV precision, True covariance and True Precision.
 
 
    *A comparison of maximum likelihood, shrinkage and sparse estimates of
@@ -340,7 +346,9 @@ attributes of a :class:`MinCovDet` robust covariance estimator object.
 .. |robust_vs_emp| image:: ../auto_examples/covariance/images/sphx_glr_plot_robust_vs_empirical_covariance_001.png
    :target: ../auto_examples/covariance/plot_robust_vs_empirical_covariance.html
    :scale: 49%
-   :alt: Two line charts comparing estimation errors that are made when using various types of location and covariance estimates on contaminated Gaussian distributed data sets.
+   :alt: Two line charts comparing estimation errors that are made when using various 
+   types of location and covariance estimates on contaminated Gaussian distributed 
+   data sets.
 
 .. |mahalanobis| image:: ../auto_examples/covariance/images/sphx_glr_plot_mahalanobis_distances_001.png
    :target: ../auto_examples/covariance/plot_mahalanobis_distances.html

--- a/doc/modules/covariance.rst
+++ b/doc/modules/covariance.rst
@@ -154,6 +154,7 @@ object to the same sample.
    :target: ../auto_examples/covariance/plot_covariance_estimation.html
    :align: center
    :scale: 65%
+   :alt:
 
    Bias-variance trade-off when setting the shrinkage: comparing the
    choices of Ledoit-Wolf and OAS estimators
@@ -178,6 +179,7 @@ object to the same sample.
    :target: ../auto_examples/covariance/plot_lw_vs_oas.html
    :align: center
    :scale: 75%
+   :alt:
 
 
 .. _sparse_inverse_covariance:
@@ -210,6 +212,7 @@ cross-validation to automatically set the ``alpha`` parameter.
    :target: ../auto_examples/covariance/plot_sparse_cov.html
    :align: center
    :scale: 60%
+   :alt:
 
    *A comparison of maximum likelihood, shrinkage and sparse estimates of
    the covariance and precision matrix in the very small samples
@@ -333,10 +336,12 @@ attributes of a :class:`MinCovDet` robust covariance estimator object.
 .. |robust_vs_emp| image:: ../auto_examples/covariance/images/sphx_glr_plot_robust_vs_empirical_covariance_001.png
    :target: ../auto_examples/covariance/plot_robust_vs_empirical_covariance.html
    :scale: 49%
+   :alt:
 
 .. |mahalanobis| image:: ../auto_examples/covariance/images/sphx_glr_plot_mahalanobis_distances_001.png
    :target: ../auto_examples/covariance/plot_mahalanobis_distances.html
    :scale: 49%
+   :alt:
 
 
 

--- a/doc/modules/covariance.rst
+++ b/doc/modules/covariance.rst
@@ -179,7 +179,8 @@ object to the same sample.
    :target: ../auto_examples/covariance/plot_lw_vs_oas.html
    :align: center
    :scale: 75%
-   :alt:
+   :alt: Two figures. One of them plots the Mean Squared Error difference between a LedoitWolf and an OAS estimator of the covariance with the y-axis from 0 to 60.  The other one compares the Shrinkage covariance estimation between the  LedoitWolf  and OAS, with the  y-axis from 0 to 1. In iboth figures the x-axis is the number of samples from 5 to 30.
+   
 
 
 .. _sparse_inverse_covariance:
@@ -212,7 +213,8 @@ cross-validation to automatically set the ``alpha`` parameter.
    :target: ../auto_examples/covariance/plot_sparse_cov.html
    :align: center
    :scale: 60%
-   :alt:
+   :alt: Various matrix using different estimators: Empircal covariance, Empircal precision, Ledoit-Wolf covariance, Ledoit-Wolf precision, GraphicaLassoCV covariance, GraphicaLassoCV precision, True covariance and True Precision.
+
 
    *A comparison of maximum likelihood, shrinkage and sparse estimates of
    the covariance and precision matrix in the very small samples
@@ -336,7 +338,7 @@ attributes of a :class:`MinCovDet` robust covariance estimator object.
 .. |robust_vs_emp| image:: ../auto_examples/covariance/images/sphx_glr_plot_robust_vs_empirical_covariance_001.png
    :target: ../auto_examples/covariance/plot_robust_vs_empirical_covariance.html
    :scale: 49%
-   :alt:
+   :alt: Two line charts comparing estimation errors that are made when using various types of location and covariance estimates on contaminated Gaussian distributed data sets.
 
 .. |mahalanobis| image:: ../auto_examples/covariance/images/sphx_glr_plot_mahalanobis_distances_001.png
    :target: ../auto_examples/covariance/plot_mahalanobis_distances.html


### PR DESCRIPTION
# Welcome!

This is the working PR for the PyLadies SWFL, PyLadies Miami, and Python SWFL alt text mini sprint (that's a lot of words)! This is where we collaborate during the event before we send a clean contribution over to the main repo.

## How to contribute

For the full info about this event, please visit the [HackMD agenda](https://hackmd.io/2uOMXV_fT0ycLyo4uH67HQ).

During the event, you can contribute alt text to any of the images on currently used in a blog post. Please contribute via [suggestions](https://hackmd.io/@marslee/BksnYfWVK) so we can easily review each other's work.

If you plan to work on a file, let people know by commenting below. We can have multiple suggestions for the same alt text, but it would be nice if we spread out to cover more images.

If you think an image is missing from these files, let @isabela-pf know and she'll add it to the PR.

## Images in this PR

To make collaborating easier, comment below with the number of the image you'd like to work on. You can do this as a group, and you can write alt text for as many images as you'd like. 

File: `doc/modules/biclustering.rst` ([Link to biclustering docs and rendered images](https://scikit-learn.org/stable/modules/biclustering.html))

- [x] 1. Line 51 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_spectral_coclustering_003.png))
- [x] 2. Line 64 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_spectral_biclustering_003.png))

File: `doc/modules/calibration.rst` ([Link to the calibration docs and rendered images](https://scikit-learn.org/stable/modules/calibration.html))

- [x] 3. Line 56 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_compare_calibration_001.png))

File: `doc/modules/clustering.rst` ([Link to the clustering docs and rendered images](https://scikit-learn.org/stable/modules/clustering.html))

- [ ] 4. Line 36 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_cluster_comparison_001.png))
- [ ] 5. Line 170 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_kmeans_assumptions_001.png))
- [ ] 6. Line 187 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_kmeans_digits_001.png))
- [x] 7. Line 278 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_mini_batch_kmeans_001.png))
- [x] 8. Line 317 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_affinity_propagation_001.png))
- [ ] 9. Line 427 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_mean_shift_001.png))
- [x] 10. Line 470 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_segmentation_toy_001.png))
- [x] 11. Line 475 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_segmentation_toy_002.png))
- [ ] 12. Line 503 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_coin_segmentation_001.png))
- [ ] 13. Line 508 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_coin_segmentation_002.png))
- [ ] 14. Line 611 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_linkage_comparison_001.png))
- [ ] 15. Line 637 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_agglomerative_dendrogram_001.png))
- [x] 16. Line 656 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_ward_structured_vs_unstructured_001.png))
- [x] 17. Line 661 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_ward_structured_vs_unstructured_002.png))
- [ ] 18. Line 711 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_agglomerative_clustering_001.png))
- [ ] 19. Line 716 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_agglomerative_clustering_002.png))
- [ ] 20. Line 721 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_agglomerative_clustering_003.png))
- [ ] 21. Line 726 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_agglomerative_clustering_004.png))
- [ ] 22. Line 751 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_agglomerative_clustering_metrics_005.png))
- [ ] 23. Line 756 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_agglomerative_clustering_metrics_006.png))
- [ ] 24. Line 761 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_agglomerative_clustering_metrics_007.png))
- [x] 25. Line 822 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_dbscan_001.png))
- [ ] 26. Line 908 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_optics_001.png))
- [ ] 27. Line 1051 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_birch_vs_minibatchkmeans_001.png))
- [ ] 28. Line 1543 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_adjusted_for_chance_measures_001.png))

File: `doc/modules/covariance.rst` [(Link to the covariance docs and rendered images](https://scikit-learn.org/stable/modules/covariance.html))

- [x] 29. Line 157 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_covariance_estimation_001.png))
- [x] 30. Line 182 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_lw_vs_oas_001.png))
- [x] 31. Line 215 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_sparse_cov_001.png))
- [x] 32. Line 339 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_robust_vs_empirical_covariance_001.png))
- [x] 33. Line 344 ([image](https://scikit-learn.org/stable/_images/sphx_glr_plot_mahalanobis_distances_001.png))

---

If you need anything, please ask @isabela-pf or @marsbarlee! 🌻 